### PR TITLE
Use new precompiled contract in ethereumjs-vm

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ethereumjs-block": "~1.2.2",
     "ethereumjs-tx": "1.3.4",
     "ethereumjs-util": "^5.2.0",
-    "ethereumjs-vm": "git+ssh://git@github.com/celo-org/ethereumjs-vm.git#0129526",
+    "ethereumjs-vm": "git+ssh://git@github.com/celo-org/ethereumjs-vm.git#08be5ea",
     "ethereumjs-wallet": "0.6.0",
     "ethereumjs-abi": "^0.6.5",
     "fake-merkle-patricia-tree": "~1.0.1",


### PR DESCRIPTION
References the PR in https://github.com/celo-org/ethereumjs-vm/pull/1 to run tests in ganache with the new precompiled contract