### PR TITLE
Predeploy reserve proxy contract

### DIFF
--- a/lib/predeployedContracts.js
+++ b/lib/predeployedContracts.js
@@ -10,6 +10,10 @@ module.exports = function(owner) {
   { address: '0x0000000000000000000000000000000000000abe',
     storage: [{key: unstructuredStorageOwnerKey, value: owner}],
     code: proxyCode
+  },
+  { address: '0x000000000000000000000000000000000000601d',
+    storage: [{key: unstructuredStorageOwnerKey, value: owner}],
+    code: proxyCode
   }
 ]
 }


### PR DESCRIPTION
This PR predeploys the reserve proxy contract, as this does not appear to be configurable via a genesis block as it is in geth.