### PR TITLE
Disable source-map-support import during jest tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 // make sourcemaps work!
-require("source-map-support/register");
+if (process.env.NODE_ENV !== "test") {
+  require("source-map-support/register");
+}
 
 const debug = require("debug")("ganache");
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,5 +1,7 @@
 // make sourcemaps work!
-require("source-map-support/register");
+if (process.env.NODE_ENV !== "test") {
+  require("source-map-support/register");
+}
 
 let ProviderEngine = require("web3-provider-engine");
 let SubscriptionSubprovider = require("web3-provider-engine/subproviders/subscriptions");

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,7 @@
 // make sourcemaps work!
-require("source-map-support/register");
+if (process.env.NODE_ENV !== "test") {
+  require("source-map-support/register");
+}
 
 var Provider = require("./provider");
 var webSocketServer = require("./webSocketServer");

--- a/public-exports.js
+++ b/public-exports.js
@@ -1,5 +1,7 @@
 // make sourcemaps work!
-require("source-map-support/register");
+if (process.env.NODE_ENV !== "test") {
+  require("source-map-support/register");
+}
 
 const Provider = require("./lib/provider");
 const Server = require("./lib/server");


### PR DESCRIPTION
This bypasses the import of `source-map-support/register` during tests which was causing incorrect line numbers in jest.

See:
- https://github.com/trufflesuite/ganache-core/issues/522
- https://github.com/kulshekhar/ts-jest/issues/727