### PR TITLE
Fix forking

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -104,10 +104,12 @@ BlockchainDouble.prototype.initialize = function(accounts, callback) {
 
         accounts = accounts || [];
 
+        const isGenesisBlock = utils.bufferToHex(block.header.parentHash) === '0x0000000000000000000000000000000000000000000000000000000000000000';
+
         self.vm.stateManager.checkpoint(() => {
           async.series(
             [
-              (next) => self.deployContract(RegistryProxy(accounts[0].address), next),
+              (next) => isGenesisBlock ? self.deployContract(RegistryProxy(accounts[0].address), next) : next(),
               (next) => {
                 async.eachSeries(
                   accounts,


### PR DESCRIPTION
### Description

Fix ganache chain-forking for currently-operational Celo chains (i.e. those with proxy contracts deployed) by only deploying Celo proxy contracts for new chains.

### Tested

**Testing a forked Celo chain**
1. Use the below to configure and launch a Celo baklava fork (place in root dir)
```
const ganacheCore = require('./index');

const networkId = 40120; // baklava
const fork = 'https://geth.celoist.com'; // baklava node rpc
const port = 8545;
const host = 'localhost';
const callback = () => null;

const ganacheServer = ganacheCore.server({
  network_id: networkId,
  fork,
});

ganacheServer.listen(port, host, callback);
```

2. Run the above `node ./ganache.js`

3. Using the Celo CLI, fetch the election list: `celocli election:list`

**Testing a brand new Celo Chain**
1. Use the below to configure and launch a new Celo chain (place in root dir)
```
const ganacheCore = require('./index');

const port = 8545;
const host = 'localhost';
const callback = () => null;

const ganacheServer = ganacheCore.server();

ganacheServer.listen(port, host, callback);
```

2. Get `RegistryProxy` code
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getCode","params":["0x000000000000000000000000000000000000ce10", "0x0"],"id":1}' http://localhost:8545
```

3. Check that it matches `proxyCode` in `lib/predeployedContracts.js`

### Related issues

N/A

### Backwards compatibility

Developers forking EVM-based chains w/o deployed Celo proxy contracts would need to do so manually or undo these changes.