### PR TITLE
Bump ethereumjs-wallet version for node 12 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "webpack-cli": "3.3.10"
   },
   "optionalDependencies": {
-    "ethereumjs-wallet": "0.6.3",
+    "ethereumjs-wallet": "0.6.4",
     "web3": "1.2.4"
   },
   "resolutions": {


### PR DESCRIPTION
The old version of ethereumjs-wallet was depending on scrypt which is
not node 12 compatible.